### PR TITLE
Template api change

### DIFF
--- a/lib/jekyll-lilypond/tag_processor.rb
+++ b/lib/jekyll-lilypond/tag_processor.rb
@@ -13,7 +13,7 @@ module Jekyll
       end
 
       def source_template_obj
-        Template.new(@site, **@tag.source_details)
+        Template.new(@site, @tag, :source)
       end
 
       def hash
@@ -26,7 +26,7 @@ module Jekyll
       end
 
       def include_template_obj
-        Template.new(@site, **@tag.include_details)
+        Template.new(@site, @tag, :include)
       end
 
       def file_processor

--- a/spec/tag_processor_spec.rb
+++ b/spec/tag_processor_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe(Jekyll::Lilypond::TagProcessor) do
 
   context "generating source code" do
     it "creates a Template using the tag data when you ask for a source template" do
-      expect(Jekyll::Lilypond::Template).to receive(:new).with(site, template_name: "NiftyTemplateName")
+      expect(Jekyll::Lilypond::Template).to receive(:new).with(site, tag, :source)
       subject.source_template_obj
     end
   end
 
   context "generating include code" do
     it "creates a Template using the tag data when you ask for an include template" do
-      expect(Jekyll::Lilypond::Template).to receive(:new).with(site, template_code: "{{ filename }} abcde")
+      expect(Jekyll::Lilypond::Template).to receive(:new).with(site, tag, :include)
       subject.include_template_obj
     end
   end


### PR DESCRIPTION
The Template class is now fully responsible for loading templates from the Site, including default ones. To support this, its constructor syntax has changed: it now receives a Site, a Tag, and a specification for :source or :include rather than just the raw text of the template. 