### PR TITLE
Include Jekyll baseurl in img src

### DIFF
--- a/lib/jekyll-lilypond/lilypond_tag.rb
+++ b/lib/jekyll-lilypond/lilypond_tag.rb
@@ -1,8 +1,6 @@
 module Jekyll
   module Lilypond
     class LilypondTag < Liquid::Block
-      @@baseurl = Jekyll.configuration({})['baseurl']
-
       def initialize(_, argtext, _)
         super
         @attributes = parse_attributes(argtext)
@@ -24,7 +22,7 @@ module Jekyll
         site =  context.registers[:site]
 
         tag = Tag.new(@attributes, content)
-        tp = TagProcessor.new(site, tag, @@baseurl)
+        tp = TagProcessor.new(site, tag)
         tp.run!
         tp.include
       end

--- a/lib/jekyll-lilypond/lilypond_tag.rb
+++ b/lib/jekyll-lilypond/lilypond_tag.rb
@@ -1,6 +1,8 @@
 module Jekyll
   module Lilypond
     class LilypondTag < Liquid::Block
+      @@baseurl = Jekyll.configuration({})['baseurl']
+
       def initialize(_, argtext, _)
         super
         @attributes = parse_attributes(argtext)
@@ -22,7 +24,7 @@ module Jekyll
         site =  context.registers[:site]
 
         tag = Tag.new(@attributes, content)
-        tp = TagProcessor.new(site, tag)
+        tp = TagProcessor.new(site, tag, @@baseurl)
         tp.run!
         tp.include
       end

--- a/lib/jekyll-lilypond/tag_processor.rb
+++ b/lib/jekyll-lilypond/tag_processor.rb
@@ -3,9 +3,10 @@ module Jekyll
     class TagProcessor
       attr_accessor :site
 
-      def initialize(site, tag)
+      def initialize(site, tag, baseurl)
         @site = site
         @tag = tag
+        @baseurl = baseurl
       end
 
       def source
@@ -22,7 +23,7 @@ module Jekyll
 
       def include
         @tag.attrs.update("filename" => hash)
-        @tag.attrs.update("baseurl" => Jekyll.configuration({})['baseurl'])
+        @tag.attrs.update("baseurl" => @baseurl)
         include_template_obj.render(@tag)
       end
 

--- a/lib/jekyll-lilypond/tag_processor.rb
+++ b/lib/jekyll-lilypond/tag_processor.rb
@@ -22,6 +22,7 @@ module Jekyll
 
       def include
         @tag.attrs.update("filename" => hash)
+        @tag.attrs.update("baseurl" => Jekyll.configuration({})['baseurl'])
         include_template_obj.render(@tag)
       end
 

--- a/lib/jekyll-lilypond/tag_processor.rb
+++ b/lib/jekyll-lilypond/tag_processor.rb
@@ -3,10 +3,9 @@ module Jekyll
     class TagProcessor
       attr_accessor :site
 
-      def initialize(site, tag, baseurl)
+      def initialize(site, tag)
         @site = site
         @tag = tag
-        @baseurl = baseurl
       end
 
       def source
@@ -23,7 +22,7 @@ module Jekyll
 
       def include
         @tag.attrs.update("filename" => hash)
-        @tag.attrs.update("baseurl" => @baseurl)
+        @tag.attrs.update("baseurl" => @site.baseurl)
         include_template_obj.render(@tag)
       end
 

--- a/lib/jekyll-lilypond/templates/img.html
+++ b/lib/jekyll-lilypond/templates/img.html
@@ -1,4 +1,4 @@
-<img src="lilypond_files/{{ filename }}.svg"
+<img src="{{ baseurl }}/lilypond_files/{{ filename }}.svg"
      alt="{{ alt }}"
      class="{{ class }}"
      style="{{ style }}"/>


### PR DESCRIPTION
This solves #18, so image paths work properly with a nonempty Jekyll `baseurl` configuration value (e.g. on GitHub Pages). If `baseurl` is empty, paths will be relative to root.

I don't have much experience with Ruby, so I'm glad to make any amendments, stylistic or otherwise.

Thanks for your gem! It's very useful!